### PR TITLE
Brewing recipe tag missing: fixed forge:egg -> forge:eggs

### DIFF
--- a/src/main/resources/data/drinkbeer/recipes/beer_mug_frothy_pink_eggnog.json
+++ b/src/main/resources/data/drinkbeer/recipes/beer_mug_frothy_pink_eggnog.json
@@ -22,7 +22,7 @@
         "item": "minecraft:egg"
       },
       {
-        "tag": "forge:egg"
+        "tag": "forge:eggs"
       }
     ],
     {


### PR DESCRIPTION
There's a tag error for the Frothy Pink Eggnog recipe.

The recipe still works with regular minecraft eggs, but the `forge:egg` tag is invalid:

![image](https://github.com/DragonsPlusMinecraft/DrinkBeerRefill/assets/56928485/ca1ab1ab-2e1c-4c4d-b47a-5472187d91de)

The tag is actually `forge:eggs`.